### PR TITLE
Fill TokenResponse.scope from the Auth callback

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -237,7 +237,9 @@ impl<A: Adapter, C: Callback> OAuth2<A, C> {
         // Have the adapter perform the token exchange.
         let token = match self.adapter.exchange_code(&self.config, &params.code) {
             Ok(mut token) => {
-                token.scope = params.scope; 
+                if token.scope == None { // if the token exchange did not provide a scope ..
+                    token.scope = params.scope; // .. use the one from the authorization exchange
+                }
                 token
             },
             Err(e) => {

--- a/src/core.rs
+++ b/src/core.rs
@@ -214,6 +214,7 @@ impl<A: Adapter, C: Callback> OAuth2<A, C> {
         struct CallbackQuery {
             code: String,
             state: String,
+            scope: Option<String>
         }
 
         let params = match CallbackQuery::from_form(&mut FormItems::from(query), false) {
@@ -235,7 +236,10 @@ impl<A: Adapter, C: Callback> OAuth2<A, C> {
 
         // Have the adapter perform the token exchange.
         let token = match self.adapter.exchange_code(&self.config, &params.code) {
-            Ok(token) => token,
+            Ok(mut token) => {
+                token.scope = params.scope; 
+                token
+            },
             Err(e) => {
                 log::error!("Token exchange failed: {:?}", e);
                 return handler::Outcome::failure(Status::BadRequest);

--- a/src/core.rs
+++ b/src/core.rs
@@ -17,7 +17,7 @@ const STATE_COOKIE_NAME: &str = "rocket_oauth2_state";
 
 /// The server's response to a successful token exchange, defined in
 /// in RFC 6749 §5.1.
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, Debug)]
 pub struct TokenResponse {
     /// The access token issued by the authorization server.
     pub access_token: String,


### PR DESCRIPTION
this is a solution to the first option in issue #2 
