### PR TITLE
Add Wikimedia as a provider

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -262,5 +262,6 @@ providers! {
     Google: "https://accounts.google.com/o/oauth2/v2/auth", "https://www.googleapis.com/oauth2/v4/token",
     Microsoft: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize", "https://login.microsoftonline.com/common/oauth2/v2.0/token",
     Reddit: "https://www.reddit.com/api/v1/authorize", "https://www.reddit.com/api/v1/access_token",
+    Wikimedia: "https://meta.wikimedia.org/w/rest.php/oauth2/authorize", "https://meta.wikimedia.org/w/rest.php/oauth2/access_token",
     Yahoo: "https://api.login.yahoo.com/oauth2/request_auth", "https://api.login.yahoo.com/oauth2/get_token",
 }


### PR DESCRIPTION
Technical documentation available at <https://www.mediawiki.org/wiki/OAuth/For_Developers#OAuth_2>.