### PR TITLE
Update hyper_sync_rustls dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ url = "2.0"
 
 # hyper-sync-rustls adapter
 hyper = { version = "0.10", optional = true }
-hyper-sync-rustls = { version = "=0.3.0-rc.*", optional = true }
+hyper-sync-rustls = { version = "=0.3.0-rc.17", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ url = "2.0"
 
 # hyper-sync-rustls adapter
 hyper = { version = "0.10", optional = true }
-hyper-sync-rustls = { version = "=0.3.0-rc.4", optional = true }
+hyper-sync-rustls = { version = "=0.3.0-rc.*", optional = true }


### PR DESCRIPTION
I was having an issue with a cargo conflict involving ring and noticed that hyper_sync_rustls had a newer release candidate. It seems to have fixed the problem and although I haven't thoroughly tested every feature, it seems to be functional now.

The error I was having:
```
error: failed to select a version for `ring`.
    ... required by package `rustls v0.17.0`
    ... which is depended on by `mongodb v1.1.0`
    ... which is depended on by `my_project`
versions that meet the requirements `^0.16.11` are: 0.16.15, 0.16.14, 0.16.13, 0.16.12, 0.16.11

the package `ring` links to the native library `ring-asm`, but it conflicts with a previous package which links to `ring-asm` as well:
package `ring v0.13.5`
    ... which is depended on by `rustls v0.14.0`
    ... which is depended on by `hyper-sync-rustls v0.3.0-rc.4`
    ... which is depended on by `rocket_oauth2 v0.4.0`
    ... which is depended on by `my_project`
```