### PR TITLE
Query constants

### DIFF
--- a/src/hyper_rustls_adapter.rs
+++ b/src/hyper_rustls_adapter.rs
@@ -126,8 +126,8 @@ impl Adapter for HyperRustlsAdapter {
         use crate::query::{header, param};
 
         let mut request = Request::post(&*config.provider().token_uri())
-            .header(ACCEPT, header::accept::APPLICATION_JSON)
-            .header(CONTENT_TYPE, header::content_type::X_WWW_FORM_URLENCODED);
+            .header(ACCEPT, header::APPLICATION_JSON)
+            .header(CONTENT_TYPE, header::X_WWW_FORM_URLENCODED);
 
         let req_str = {
             let mut ser = UrlSerializer::new(String::new());

--- a/src/hyper_rustls_adapter.rs
+++ b/src/hyper_rustls_adapter.rs
@@ -126,7 +126,7 @@ impl Adapter for HyperRustlsAdapter {
         use crate::query::{header, param};
 
         let mut request = Request::post(&*config.provider().token_uri())
-            .header(ACCEPT, header::accept::ACCEPT_APPLICATION_JSON)
+            .header(ACCEPT, header::accept::APPLICATION_JSON)
             .header(CONTENT_TYPE, header::content_type::X_WWW_FORM_URLENCODED);
 
         let req_str = {

--- a/src/hyper_rustls_adapter.rs
+++ b/src/hyper_rustls_adapter.rs
@@ -80,33 +80,35 @@ impl Adapter for HyperRustlsAdapter {
         scopes: &[&str],
         extra_params: &[(&str, &str)],
     ) -> Result<Absolute<'static>, Error> {
+        use crate::query::param;
+
         let auth_uri = config.provider().auth_uri();
 
         let mut url = Url::parse(&auth_uri)
             .map_err(|e| Error::new_from(ErrorKind::InvalidUri(auth_uri.to_string()), e))?;
 
         url.query_pairs_mut()
-            .append_pair("response_type", "code")
-            .append_pair("client_id", config.client_id())
-            .append_pair("state", state);
+            .append_pair(param::RESPONSE_TYPE, param::response_type::CODE)
+            .append_pair(param::CLIENT_ID, config.client_id())
+            .append_pair(param::STATE, state);
 
         if let Some(redirect_uri) = config.redirect_uri() {
             url.query_pairs_mut()
-                .append_pair("redirect_uri", redirect_uri);
+                .append_pair(param::REDIRECT_URI, redirect_uri);
         }
 
         if !scopes.is_empty() {
             url.query_pairs_mut()
-                .append_pair("scope", &scopes.join(" "));
+                .append_pair(param::SCOPE, &scopes.join(" "));
         }
 
         // Request parameters must not be included more than once. This
         // adapter chooses to ignore duplicates instead of overwriting.
         for (name, value) in extra_params {
             match *name {
-                "response_type" | "client_id" | "state" => continue,
-                "redirect_uri" if config.redirect_uri().is_some() => continue,
-                "scope" if !scopes.is_empty() => continue,
+                param::RESPONSE_TYPE | param::CLIENT_ID | param::STATE => continue,
+                param::REDIRECT_URI if config.redirect_uri().is_some() => continue,
+                param::SCOPE if !scopes.is_empty() => continue,
                 _ => url.query_pairs_mut().append_pair(name, value),
             };
         }
@@ -121,23 +123,25 @@ impl Adapter for HyperRustlsAdapter {
         config: &OAuthConfig,
         token: TokenRequest,
     ) -> Result<TokenResponse<()>, Error> {
+        use crate::query::{header, param};
+
         let mut request = Request::post(&*config.provider().token_uri())
-            .header(ACCEPT, "application/json")
-            .header(CONTENT_TYPE, "application/x-www-form-urlencoded");
+            .header(ACCEPT, header::accept::ACCEPT_APPLICATION_JSON)
+            .header(CONTENT_TYPE, header::content_type::X_WWW_FORM_URLENCODED);
 
         let req_str = {
             let mut ser = UrlSerializer::new(String::new());
             match token {
                 TokenRequest::AuthorizationCode(code) => {
-                    ser.append_pair("grant_type", "authorization_code");
-                    ser.append_pair("code", &code);
+                    ser.append_pair(param::GRANT_TYPE, param::grant_type::AUTHORIZATION_CODE);
+                    ser.append_pair(param::CODE, &code);
                     if let Some(redirect_uri) = config.redirect_uri() {
-                        ser.append_pair("redirect_uri", redirect_uri);
+                        ser.append_pair(param::REDIRECT_URI, redirect_uri);
                     }
                 }
                 TokenRequest::RefreshToken(token) => {
-                    ser.append_pair("grant_type", "refresh_token");
-                    ser.append_pair("refresh_token", &token);
+                    ser.append_pair(param::GRANT_TYPE, param::grant_type::REFRESH_TOKEN);
+                    ser.append_pair(param::REFRESH_TOKEN, &token);
                 }
             }
 
@@ -146,8 +150,8 @@ impl Adapter for HyperRustlsAdapter {
                     base64::encode(format!("{}:{}", config.client_id(), config.client_secret()));
                 request = request.header(AUTHORIZATION, format!("Basic {}", encoded))
             } else {
-                ser.append_pair("client_id", config.client_id());
-                ser.append_pair("client_secret", config.client_secret());
+                ser.append_pair(param::CLIENT_ID, config.client_id());
+                ser.append_pair(param::CLIENT_SECRET, config.client_secret());
             }
 
             ser.finish()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@
 
 mod config;
 mod error;
+pub mod query;
 
 #[cfg(feature = "hyper_rustls_adapter")]
 mod hyper_rustls_adapter;

--- a/src/query.rs
+++ b/src/query.rs
@@ -9,7 +9,7 @@ pub mod header {
         /// `application/json`, [JSON]-formatted data.
         ///
         /// [JSON]: https://datatracker.ietf.org/doc/html/rfc7159
-        pub const ACCEPT_APPLICATION_JSON: &str = "application/json";
+        pub const APPLICATION_JSON: &str = "application/json";
     }
 
     /// Common values of HTTP [`Content-Type`] header.

--- a/src/query.rs
+++ b/src/query.rs
@@ -6,7 +6,7 @@ pub mod header {
     ///
     /// [`Accept`]: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2
     pub mod accept {
-        /// [JSON]-formatted data.
+        /// `application/json`, [JSON]-formatted data.
         ///
         /// [JSON]: https://datatracker.ietf.org/doc/html/rfc7159
         pub const ACCEPT_APPLICATION_JSON: &str = "application/json";
@@ -16,7 +16,7 @@ pub mod header {
     ///
     /// [`Content-Type`]: https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.5
     pub mod content_type {
-        /// [Form-based] data encoded into a URL.
+        /// `application/x-www-form-urlencoded`, [form-based] data encoded into a URL.
         ///
         /// [Form-based]: https://www.ietf.org/rfc/rfc1867
         pub const X_WWW_FORM_URLENCODED: &str = "application/x-www-form-urlencoded";
@@ -26,52 +26,53 @@ pub mod header {
 /// Constants corresponding to URL parameter names
 /// and their common values for OAuth2 implementation.
 pub mod param {
-    /// The client identifier issued to the client during the registration process.
+    /// `client_id`, the client identifier issued to the client during the registration process.
     pub const CLIENT_ID: &str = "client_id";
 
-    /// The client secret.
+    /// `client_secret`, the client secret.
     pub const CLIENT_SECRET: &str = "client_secret";
 
-    /// The authorization code received from the authorization server.
+    /// `code`, the authorization code received from the authorization server.
     pub const CODE: &str = "code";
 
-    /// Extension grant type.
+    /// `grant_type`, extension grant type.
     pub const GRANT_TYPE: &str = "grant_type";
 
     /// Common values of `grant_type` parameter.
     pub mod grant_type {
-        /// Grant type for OAuth2 [Access Token Request].
+        /// `authorization_code`, grant type for OAuth2 [Access Token Request].
         ///
         /// [Access Token Request]: https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
         pub const AUTHORIZATION_CODE: &str = "authorization_code";
 
-        /// Grant type for OAuth2 [Refreshing an Access Token].
+        /// `refresh_token`, grant type for OAuth2 [Refreshing an Access Token].
         ///
         /// [Refreshing an Access Token]: https://datatracker.ietf.org/doc/html/rfc6749#section-6
         pub const REFRESH_TOKEN: &str = "refresh_token";
     }
 
-    /// The endpoint to which the authorization server redirects the user-agent.
+    /// `redirect_uri`, the endpoint to which the authorization server redirects the user-agent.
     pub const REDIRECT_URI: &str = "redirect_uri";
 
-    /// The refresh token, which can be used to obtain
+    /// `refresh_token`, the refresh token, which can be used to obtain
     /// new access tokens using the same authorization grant.
     pub const REFRESH_TOKEN: &str = "refresh_token";
 
-    /// Type of response requested from the authorization server.
+    /// `response_type`, type of response requested from the authorization server.
     pub const RESPONSE_TYPE: &str = "response_type";
 
     /// Common values of `response_type` parameter.
     pub mod response_type {
 
-        /// Response type for OAuth2 [Authorization Request].
+        /// `code`, response type for OAuth2 [Authorization Request].
         /// [Authorization Request]: https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
         pub const CODE: &str = "code";
     }
 
-    /// The scope of the access request.
+    /// `scope`, the scope of the access request.
     pub const SCOPE: &str = "scope";
 
-    /// An opaque value used by the client to maintain state between the request and callback.
+    /// `state`, an opaque value used by the client
+    /// to maintain state between the request and callback.
     pub const STATE: &str = "state";
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,25 +2,18 @@
 
 /// Common constants for HTTP headers
 pub mod header {
-    /// Common values of HTTP [`Accept`] header.
+    /// `application/json` value of [`Accept`] header corresponding to [JSON]-formatted data.
     ///
     /// [`Accept`]: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2
-    pub mod accept {
-        /// `application/json`, [JSON]-formatted data.
-        ///
-        /// [JSON]: https://datatracker.ietf.org/doc/html/rfc7159
-        pub const APPLICATION_JSON: &str = "application/json";
-    }
+    /// [JSON]: https://datatracker.ietf.org/doc/html/rfc7159
+    pub const APPLICATION_JSON: &str = "application/json";
 
-    /// Common values of HTTP [`Content-Type`] header.
+    /// `application/x-www-form-urlencoded` value of [`Content-Type`] header
+    /// corresponding to [form-based] data encoded into a URL.
     ///
     /// [`Content-Type`]: https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.5
-    pub mod content_type {
-        /// `application/x-www-form-urlencoded`, [form-based] data encoded into a URL.
-        ///
-        /// [Form-based]: https://www.ietf.org/rfc/rfc1867
-        pub const X_WWW_FORM_URLENCODED: &str = "application/x-www-form-urlencoded";
-    }
+    /// [Form-based]: https://www.ietf.org/rfc/rfc1867
+    pub const X_WWW_FORM_URLENCODED: &str = "application/x-www-form-urlencoded";
 }
 
 /// Constants corresponding to URL parameter names
@@ -63,7 +56,6 @@ pub mod param {
 
     /// Common values of `response_type` parameter.
     pub mod response_type {
-
         /// `code`, response type for OAuth2 [Authorization Request].
         /// [Authorization Request]: https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
         pub const CODE: &str = "code";

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,77 @@
+//! Constants corresponding to standard HTTP names.
+
+/// Common constants for HTTP headers
+pub mod header {
+    /// Common values of HTTP [`Accept`] header.
+    ///
+    /// [`Accept`]: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2
+    pub mod accept {
+        /// [JSON]-formatted data.
+        ///
+        /// [JSON]: https://datatracker.ietf.org/doc/html/rfc7159
+        pub const ACCEPT_APPLICATION_JSON: &str = "application/json";
+    }
+
+    /// Common values of HTTP [`Content-Type`] header.
+    ///
+    /// [`Content-Type`]: https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.5
+    pub mod content_type {
+        /// [Form-based] data encoded into a URL.
+        ///
+        /// [Form-based]: https://www.ietf.org/rfc/rfc1867
+        pub const X_WWW_FORM_URLENCODED: &str = "application/x-www-form-urlencoded";
+    }
+}
+
+/// Constants corresponding to URL parameter names
+/// and their common values for OAuth2 implementation.
+pub mod param {
+    /// The client identifier issued to the client during the registration process.
+    pub const CLIENT_ID: &str = "client_id";
+
+    /// The client secret.
+    pub const CLIENT_SECRET: &str = "client_secret";
+
+    /// The authorization code received from the authorization server.
+    pub const CODE: &str = "code";
+
+    /// Extension grant type.
+    pub const GRANT_TYPE: &str = "grant_type";
+
+    /// Common values of `grant_type` parameter.
+    pub mod grant_type {
+        /// Grant type for OAuth2 [Access Token Request].
+        ///
+        /// [Access Token Request]: https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
+        pub const AUTHORIZATION_CODE: &str = "authorization_code";
+
+        /// Grant type for OAuth2 [Refreshing an Access Token].
+        ///
+        /// [Refreshing an Access Token]: https://datatracker.ietf.org/doc/html/rfc6749#section-6
+        pub const REFRESH_TOKEN: &str = "refresh_token";
+    }
+
+    /// The endpoint to which the authorization server redirects the user-agent.
+    pub const REDIRECT_URI: &str = "redirect_uri";
+
+    /// The refresh token, which can be used to obtain
+    /// new access tokens using the same authorization grant.
+    pub const REFRESH_TOKEN: &str = "refresh_token";
+
+    /// Type of response requested from the authorization server.
+    pub const RESPONSE_TYPE: &str = "response_type";
+
+    /// Common values of `response_type` parameter.
+    pub mod response_type {
+
+        /// Response type for OAuth2 [Authorization Request].
+        /// [Authorization Request]: https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
+        pub const CODE: &str = "code";
+    }
+
+    /// The scope of the access request.
+    pub const SCOPE: &str = "scope";
+
+    /// An opaque value used by the client to maintain state between the request and callback.
+    pub const STATE: &str = "state";
+}


### PR DESCRIPTION
# Description

This adds a `pub mod query` which stores a number of submodules holding `&str` constants related to common HTTP values which may (and should) be used by `Adapter` implementation.

This approach is less error-prone as changing adapter is now safe from typos thus making it easier to implement other adapters.