### PR TITLE
Update for Discord domain name change

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -232,7 +232,7 @@ macro_rules! providers {
 }
 
 providers! {
-    Discord: "https://discord.com/api/oauth2/authorize", "https://discord.com/api/oauth2/token",
+    Discord: "https://discord.com/oauth2/authorize", "https://discord.com/api/oauth2/token",
     Facebook: "https://www.facebook.com/v3.1/dialog/oauth", "https://graph.facebook.com/v3.1/oauth/access_token",
     GitHub: "https://github.com/login/oauth/authorize", "https://github.com/login/oauth/access_token",
     Google: "https://accounts.google.com/o/oauth2/v2/auth", "https://www.googleapis.com/oauth2/v4/token",

--- a/src/config.rs
+++ b/src/config.rs
@@ -232,7 +232,7 @@ macro_rules! providers {
 }
 
 providers! {
-    Discord: "https://discordapp.com/api/oauth2/authorize", "https://discordapp.com/api/oauth2/token",
+    Discord: "https://discord.com/api/oauth2/authorize", "https://discord.com/api/oauth2/token",
     Facebook: "https://www.facebook.com/v3.1/dialog/oauth", "https://graph.facebook.com/v3.1/oauth/access_token",
     GitHub: "https://github.com/login/oauth/authorize", "https://github.com/login/oauth/access_token",
     Google: "https://accounts.google.com/o/oauth2/v2/auth", "https://www.googleapis.com/oauth2/v4/token",


### PR DESCRIPTION
[Discord moved from discordapp.com to discord.com in 2020.](https://support.discord.com/hc/en-us/articles/360042987951) This updates the `StaticProvider::Discord` constant accordingly, which I think skips a redirect, and is a good idea anyway in case the old name stops working at some point. I've been using a provider defined this way in production for a while now and it seems to be working without any issues.